### PR TITLE
Main

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -153,7 +153,7 @@ jobs:
                   submodules: recursive
 
             - name: Set up Python 3.12
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: 3.12
 

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -180,7 +180,7 @@ jobs:
 
         steps:
             - name: Download artifact
-              uses: actions/download-artifact@v5
+              uses: actions/download-artifact@v6
               with:
                   path: dist
                   merge-multiple: true

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -100,7 +100,7 @@ jobs:
                   CC: ${{ steps.setup-fortran.outputs.cc }}
 
             - name: Build and test wheels
-              uses: pypa/cibuildwheel@v3.1.4
+              uses: pypa/cibuildwheel@v3.2.1
 
               env:
                   CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform }}

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -133,7 +133,7 @@ jobs:
                       cd /d {project} && python -m pytest
 
             - name: Upload wheel as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               with:
                   name: |
                     ${{ matrix.os }}-${{ matrix.python }}-${{ matrix.platform }}
@@ -163,7 +163,7 @@ jobs:
                   python -m build --sdist .
 
             - name: Upload sdist as artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               with:
                   name: artifact-sdist
                   path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
                   submodules: recursive
 
             - name: Set up Python ${{ matrix.python-versions }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-versions }}
 


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflows to use newer versions of build and artifact GitHub Actions.

CI:
- Bump cibuildwheel in the PyPI packaging workflow to the latest 3.2.x release.
- Upgrade actions/upload-artifact and actions/download-artifact to v5 and v6 respectively in packaging workflows.
- Update actions/setup-python to v6 across packaging and test workflows.